### PR TITLE
Add layout building by strings

### DIFF
--- a/src/main/java/io/github/mqzen/menus/base/Content.java
+++ b/src/main/java/io/github/mqzen/menus/base/Content.java
@@ -110,7 +110,6 @@ public interface Content {
 	void trim(int maxButtonsCount);
 	
 	class Builder {
-		
 		private final MenuContentImpl impl;
 		private final Capacity capacity;
 		
@@ -119,6 +118,15 @@ public interface Content {
 			impl = new MenuContentImpl(capacity);
 		}
 		
+		public Builder layout(Layout layout) {
+			for (int row = 0; row < capacity.getRows(); row++) {
+				for (int column = 0; column < capacity.getColumns(); column++) {
+					impl.setButton(Slot.of(row, column), layout.getMappedButton(row, column));
+				}
+			}
+			return this;
+		}
+
 		public Builder setButton(Slot slot, Button button) {
 			impl.setButton(slot, button);
 			return this;
@@ -229,14 +237,9 @@ public interface Content {
 		public Builder draw(Direction direction, ItemStack itemStack) {
 			return iterate(direction, (content, slot) -> content.setButton(slot, Button.empty(itemStack)));
 		}
-		
-		
+
 		public Content build() {
 			return impl;
 		}
-		
-		
 	}
-	
-	
 }

--- a/src/main/java/io/github/mqzen/menus/base/Layout.java
+++ b/src/main/java/io/github/mqzen/menus/base/Layout.java
@@ -1,0 +1,60 @@
+package io.github.mqzen.menus.base;
+
+import io.github.mqzen.menus.misc.Button;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class Layout {
+    @NotNull
+    private final Map<Character, Button> mappedButtons;
+
+    @NotNull
+    private final String[] patterns;
+
+    Layout(@NotNull Map<Character, Button> mappedButtons, final String[] patterns) {
+        this.mappedButtons = mappedButtons;
+        this.patterns = patterns;
+    }
+
+    public Button getMappedButton(int row, int column) {
+        Objects.checkFromToIndex(1, 6, row);
+        Objects.checkFromToIndex(1, 9, column);
+
+        String pattern = patterns[row];
+        return this.mappedButtons.get(pattern.charAt(column));
+    }
+
+    @NotNull
+    @Contract(pure = true)
+    public static LayoutBuilder builder() {
+        return new LayoutBuilder();
+    }
+
+    public static class LayoutBuilder {
+        private final Map<Character, Button> mappedButtons;
+
+        LayoutBuilder() {
+            this.mappedButtons = new HashMap<>();
+        }
+
+        public LayoutBuilder set(char mapper, Button button) {
+            this.mappedButtons.put(mapper, button);
+            return this;
+        }
+
+        public Layout create(String... patterns) {
+            Objects.requireNonNull(patterns, "Pattern array must NOT be null.");
+            Objects.checkFromToIndex(1, 6, patterns.length);
+
+            for (String pattern : patterns)
+                Objects.checkFromToIndex(1, 9, pattern.length());
+
+            return new Layout(mappedButtons, patterns);
+        }
+    }
+}


### PR DESCRIPTION
## Goals
- To add the ability to build contents using a built-in layout builder, provide a couple of strings and some mappers from characters to buttons.

## Non-Goals
- It is not an attempt to replace manual modifications to a menu not layout built.

Example:
```java
Capacity capacity = Capacity.of(...);

Content content = Content.builder(capacity)
        .layout(Layout.builder()
                        .set('X', Button.empty(...))
                        .set('Y', Button.clickable(...))
                        .create(
                            "XXXXXXXXX"
                            "XY    YX"
                            "YYYYYYYYY"
                         )
        )
        .draw(..., ...)
        .build();
        
// Do stuff with "content".
```