### PR TITLE
fix: onClose triggering whilst switching menus

### DIFF
--- a/src/main/java/io/github/mqzen/menus/Lotus.java
+++ b/src/main/java/io/github/mqzen/menus/Lotus.java
@@ -83,6 +83,10 @@ public final class Lotus {
 	private void registerOpeners() {
 		//TODO register the rest of openers
 	}
+
+	public void registerCustomOpener(InventoryType inventoryType, ViewOpener opener) {
+		openers.put(inventoryType, opener);
+	}
 	
 	public void enableDebugger() {
 		this.debugger = new LotusDebugger(plugin.getLogger());
@@ -311,7 +315,11 @@ public final class Lotus {
 		public void onClose(InventoryCloseEvent e) {
 			Player closer = (Player) e.getPlayer();
 			Lotus.this.debug("Triggering InventoryCloseEvent");
-			Lotus.this.getMenuView(closer.getUniqueId()).ifPresent((menu) -> Lotus.this.closeView(menu, e));
+			Lotus.this.getMenuView(closer.getUniqueId()).ifPresent((menu) -> {
+				if (e.getInventory().getHolder() != menu) return;
+
+				Lotus.this.closeView(menu, e);
+			});
 		}
 
 		@EventHandler(priority = EventPriority.LOW)

--- a/src/main/java/io/github/mqzen/menus/Lotus.java
+++ b/src/main/java/io/github/mqzen/menus/Lotus.java
@@ -312,7 +312,11 @@ public final class Lotus {
 			Player closer = (Player) e.getPlayer();
 			Lotus.this.debug("Triggering InventoryCloseEvent");
 			Lotus.this.getMenuView(closer.getUniqueId()).ifPresent((menu) -> {
-				if (e.getInventory().getHolder() != menu) return;
+				if (e.getInventory().getHolder() != menu) {
+					MenuView<?> previousMenuView = (MenuView<?>) e.getInventory().getHolder();
+					Lotus.this.closeView(previousMenuView, e);
+					return;
+				}
 
 				Lotus.this.closeView(menu, e);
 			});

--- a/src/main/java/io/github/mqzen/menus/Lotus.java
+++ b/src/main/java/io/github/mqzen/menus/Lotus.java
@@ -83,10 +83,6 @@ public final class Lotus {
 	private void registerOpeners() {
 		//TODO register the rest of openers
 	}
-
-	public void registerCustomOpener(InventoryType inventoryType, ViewOpener opener) {
-		openers.put(inventoryType, opener);
-	}
 	
 	public void enableDebugger() {
 		this.debugger = new LotusDebugger(plugin.getLogger());


### PR DESCRIPTION
opening a menu whilst being in one triggers the onclose method from the opened menu

like if im in one lotus menu
and i open another one whilst still being in the previous one
it triggers the opened menu's onclose